### PR TITLE
Add class method globalize_attribute_names

### DIFF
--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -2,10 +2,12 @@ require 'globalize'
 
 module Globalize::Accessors
   attr_reader :globalize_locales
+  attr_reader :globalize_attribute_names
 
   def globalize_accessors(options = {})
     options.reverse_merge!(:locales => I18n.available_locales, :attributes => translated_attribute_names)
     @globalize_locales = options[:locales]
+    @globalize_attribute_names = []
 
     each_attribute_and_locale(options) do |attr_name, locale|
       define_accessors(attr_name, locale)
@@ -29,12 +31,15 @@ module Globalize::Accessors
   end
 
   def define_setter(attr_name, locale)
-    define_method :"#{attr_name}_#{locale.to_s.underscore}=" do |value|
+    localized_attr_name = "#{attr_name}_#{locale.to_s.underscore}"
+
+    define_method :"#{localized_attr_name}=" do |value|
       write_attribute(attr_name, value, :locale => locale)
     end
     if respond_to?(:accessible_attributes) && accessible_attributes.include?(attr_name)
-      attr_accessible :"#{attr_name}_#{locale.to_s.underscore}"
+      attr_accessible :"#{localized_attr_name}"
     end
+    @globalize_attribute_names << localized_attr_name.to_sym
   end
 
   def each_attribute_and_locale(options)

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,25 @@ You can also get the accessor locales for a class with the `globalize_locales` m
   Product.globalize_locales # => [:en, :pl]
 ````
 
+You can also get modified attribute names - ideal to strong parameters usage - with "globalize_attribute_names" method:
+
+````ruby
+Product.globalize_attribute_names # => [:title_en, :title_pl]
+````
+
+Example usage with strong parameters:
+
+````ruby
+params.require(:product).permit(*Product.globalize_attribute_names)
+````
+
+If you need none translatable attributes as well, you could do:
+
+````ruby
+permitted = Product.globalize_attribute_names + [:position]
+params.require(:product).permit(*permitted)
+````
+
 ## Always define accessors
 
 If you wish to always define accessors and don't want to call the globalize_accessors method in every class, you can extend ActiveRecord::Base with a module:

--- a/test/globalize_accessors_test.rb
+++ b/test/globalize_accessors_test.rb
@@ -133,4 +133,12 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
     assert_equal "Name pt-BR",  u.name_pt_br
     assert_equal "Name en-AU",  u.name_en_au
   end
+
+  test "globalize attribute names on class without attributes specified in options" do
+    assert_equal [:name_en, :name_pl, :title_en, :title_pl], Unit.globalize_attribute_names
+  end
+
+  test "globalize attribute names on class with attributes specified in options" do
+    assert_equal [:name_pl], UnitTranslatedWithOptions.globalize_attribute_names
+  end
 end


### PR DESCRIPTION
Allow to get modified attribute names - ideal to strong parameters usage - with “globalize_attribute_names” method:

Product.globalize_attribute_names # => [:title_en, :title_pl]

Note: Patched, Tested, Documented on ReadMe
