### PR TITLE
Fallback support for globalize accessors

### DIFF
--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -25,7 +25,7 @@ module Globalize::Accessors
 
   def define_getter(attr_name, locale)
     define_method :"#{attr_name}_#{locale.to_s.underscore}" do
-      read_attribute(attr_name, :locale => locale)
+      globalize.stash.contains?(locale, attr_name) ? globalize.send(:fetch_stash, locale, attr_name) : globalize.send(:fetch_attribute, locale, attr_name)
     end
   end
 

--- a/test/globalize_accessors_test.rb
+++ b/test/globalize_accessors_test.rb
@@ -144,6 +144,17 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
     assert_equal "Name en-AU",  u.name_en_au
   end
 
+  test "read when fallbacks present" do
+    u = Unit.create!(:name_en => "Name en", :title_pl => "Title pl")
+    u = Unit.find(u.id)
+    def u.globalize_fallbacks(locale)
+      locale == :pl ? [:pl, :en] : [:en, :pl]
+    end
+
+    assert_equal "Name en",  u.name
+    assert_nil u.title_en
+  end
+
   test "globalize attribute names on class without attributes specified in options" do
     assert_equal [:name_en, :name_pl, :title_en, :title_pl], Unit.globalize_attribute_names
   end


### PR DESCRIPTION
When using a locale specific accessor, we always want to get the raw
value of the localization, without using any fallback.

If we don't use this approach, and have an admin interface for
localizing a record, simply showing the edit screen and then saving
without changing anything will result in the fallback value being
inserted into the db. This makes it hard to find what translations are
outstanding, and unnecessarily polutes the database.
