### PR TITLE
Build translation when writing an attribute

### DIFF
--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -13,15 +13,12 @@ module Globalize::Accessors
     end
   end
 
-
   private
-
 
   def define_accessors(attr_name, locale)
     define_getter(attr_name, locale)
     define_setter(attr_name, locale)
   end
-
 
   def define_getter(attr_name, locale)
     define_method :"#{attr_name}_#{locale.to_s.underscore}" do
@@ -34,6 +31,7 @@ module Globalize::Accessors
 
     define_method :"#{localized_attr_name}=" do |value|
       write_attribute(attr_name, value, :locale => locale)
+      translation_for(locale)[attr_name] = value if value.present?
     end
     if respond_to?(:accessible_attributes) && accessible_attributes.include?(attr_name)
       attr_accessible :"#{localized_attr_name}"

--- a/test/globalize_accessors_test.rb
+++ b/test/globalize_accessors_test.rb
@@ -51,6 +51,17 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
     assert_nil u.title_en
   end
 
+  test "build translations for a new object" do
+    u = Unit.new(:name_en => "Name en", :title_pl => "Title pl")
+    assert_equal 2, u.translations.size # size of the collection
+    assert_equal 0, u.translations.count # count from database
+  end
+
+  test "doesn't build translations without values" do
+    u = Unit.new(:name_en => nil, :title_pl => " ")
+    assert_equal 0, u.translations.size
+  end
+
   test "write on new object and read on saved" do
     u = Unit.create!(:name_en => "Name en", :title_pl => "Title pl")
 
@@ -60,6 +71,14 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
 
     assert_nil u.name_pl
     assert_nil u.title_en
+  end
+
+   test "updates translations for existing object" do
+    u = Unit.create!(:name_en => "Name en", :title_pl => "Title pl")
+    u.name_en = "New name en"
+    assert_equal "New name en", u.translations.find {|t| t.locale == :en }.name
+    assert_equal "Title pl", u.translations.find {|t| t.locale == :pl }.title
+    assert_equal 2, u.translations.count
   end
 
   test "read on existing object" do


### PR DESCRIPTION
Returns a new translation that has been instantiated with the locale and
linked to the record. Useful when creating custom validations on the
translations before saving the associated object.
