### PR TITLE
Extract localized_attr_name_for method

### DIFF
--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -11,6 +11,12 @@ module Globalize::Accessors
     each_attribute_and_locale(options) do |attr_name, locale|
       define_accessors(attr_name, locale)
     end
+
+    include InstanceMethods
+  end
+
+  def localized_attr_name_for(attr_name, locale)
+    "#{attr_name}_#{locale.to_s.underscore}"
   end
 
   private
@@ -21,13 +27,13 @@ module Globalize::Accessors
   end
 
   def define_getter(attr_name, locale)
-    define_method :"#{attr_name}_#{locale.to_s.underscore}" do
+    define_method localized_attr_name_for(attr_name, locale) do
       globalize.stash.contains?(locale, attr_name) ? globalize.send(:fetch_stash, locale, attr_name) : globalize.send(:fetch_attribute, locale, attr_name)
     end
   end
 
   def define_setter(attr_name, locale)
-    localized_attr_name = "#{attr_name}_#{locale.to_s.underscore}"
+    localized_attr_name = localized_attr_name_for(attr_name, locale)
 
     define_method :"#{localized_attr_name}=" do |value|
       write_attribute(attr_name, value, :locale => locale)
@@ -47,6 +53,11 @@ module Globalize::Accessors
     end
   end
 
+  module InstanceMethods
+    def localized_attr_name_for(attr_name, locale)
+      self.class.localized_attr_name_for(attr_name, locale)
+    end
+  end
 end
 
 ActiveRecord::Base.extend Globalize::Accessors

--- a/test/globalize_accessors_test.rb
+++ b/test/globalize_accessors_test.rb
@@ -36,8 +36,20 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
     globalize_accessors :locales => [:"pt-BR", :"en-AU"], :attributes => [:name]
   end
 
+  class UnitWithoutAccessors < ActiveRecord::Base
+    self.table_name = :units
+  end
+
   setup do
     assert_equal :en, I18n.locale
+  end
+
+  test "return localized attribute names" do
+    u = UnitWithDashedLocales.new
+
+    assert_equal "name_en", u.localized_attr_name_for(:name, :en)
+    assert_equal "name_pt_br", u.localized_attr_name_for(:name, :"pt-BR")
+    assert_equal "name_zh_cn", u.class.localized_attr_name_for(:name, :"zh-CN")
   end
 
   test "read and write on new object" do
@@ -195,5 +207,9 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
   test "instance cannot set globalize locales or attributes" do
     assert_raise(NoMethodError) { Unit.new.globalize_attribute_names = [:name] }
     assert_raise(NoMethodError) { Unit.new.globalize_locales = [:en, :de] }
+  end
+
+  test "instance without accessors" do
+    refute UnitWithoutAccessors.new.respond_to?(:localized_attr_name_for)
   end
 end


### PR DESCRIPTION
Expose convention for localized attribute names.
