### PR TITLE
Not creating translations after saving for empty values

### DIFF
--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -36,7 +36,7 @@ module Globalize::Accessors
     localized_attr_name = localized_attr_name_for(attr_name, locale)
 
     define_method :"#{localized_attr_name}=" do |value|
-      return if !translation_caches[locale] and value.blank?
+      return if !translation_caches[locale] && value.blank?
       write_attribute(attr_name, value, :locale => locale)
       translation_for(locale)[attr_name] = value
     end

--- a/test/globalize_accessors_test.rb
+++ b/test/globalize_accessors_test.rb
@@ -80,8 +80,8 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
 
     # On Rails 4, Globalize will always create an empty translation for
     # the default locale
-    # On Rails 3, Globalize will always create no translation
-    assert (not u.translated_locales.include?(:pl))
+    # On Rails 3, Globalize will never create a translation
+    assert u.translated_locales.exclude?(:pl)
   end
 
   test "persisted translations can be set to empty values" do


### PR DESCRIPTION
Hi,
if an accessor is used to set an empty value the translation is still created after saving, because `write_attribute` is still being called.

this fixes that behaviour.
