### PR TITLE
Change to translation_for

### DIFF
--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -36,7 +36,7 @@ module Globalize::Accessors
     localized_attr_name = localized_attr_name_for(attr_name, locale)
 
     define_method :"#{localized_attr_name}=" do |value|
-      return if !translation_caches[locale] && value.blank?
+      return if !translation_for(locale) && value.blank?
       write_attribute(attr_name, value, :locale => locale)
       translation_for(locale)[attr_name] = value
     end


### PR DESCRIPTION
Change the setter to !translation_for(locale) it is now possible that
the cache is empty but the DB has already a translation so the update
still fails. The unit tests are first reading which fills the cache already...