### PR TITLE
Rails 4.2 and globalize 5.0 support.

### DIFF
--- a/globalize-accessors.gemspec
+++ b/globalize-accessors.gemspec
@@ -14,19 +14,11 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3"
   s.rubyforge_project         = "globalize-accessors"
 
-  if ENV['RAILS_3']
-    s.add_dependency "globalize", "~> 3.0.0"
-  elsif ENV['RAILS_4']
-    s.add_dependency "globalize", "~> 4.0.0.alpha.1"
-  else
-    s.add_dependency "globalize", ">= 3"
-  end
-
-  s.add_development_dependency "bundler", ">= 1.3.5"
+  s.add_dependency "globalize", "~> 5.0.0"
+  s.add_development_dependency "bundler", "~> 1.7.2"
   s.add_development_dependency "rake", "~> 0.9.2"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "minitest", "~> 4.2"
-
+  s.add_development_dependency "minitest", "~> 5.1"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact

--- a/lib/globalize-accessors/version.rb
+++ b/lib/globalize-accessors/version.rb
@@ -1,5 +1,5 @@
 module Globalize
   module Accessors
-    VERSION = '0.1.5'
+    VERSION = '0.2.0'
   end
 end

--- a/test/globalize_accessors_test.rb
+++ b/test/globalize_accessors_test.rb
@@ -17,17 +17,15 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
   end
 
   class UnitInheritedWithOptions < ActiveRecord::Base
+    self.table_name = :units
     translates :color
     globalize_accessors :locales => [:de], :attributes => [:color]
   end
 
-  if ENV['RAILS_3']
-    class UnitWithAttrAccessible < ActiveRecord::Base
-      self.table_name = :units
-      attr_accessible :name
-      translates :name, :title
-      globalize_accessors
-    end
+  class UnitWithAttrAccessible < ActiveRecord::Base
+    self.table_name = :units
+    translates :name, :title
+    globalize_accessors
   end
 
   class UnitWithDashedLocales < ActiveRecord::Base
@@ -158,18 +156,6 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
 
     assert_equal "Name en",  u.name
     assert_equal "Name pl",  u.name_pl
-  end
-
-  if ENV['RAILS_3']
-    test "whitelist locale accessors if the original attribute is whitelisted" do
-      u = UnitWithAttrAccessible.new()
-      u.update_attributes(:name => "Name en", :name_pl => "Name pl", :title => "Title en", :title_pl => "Title pl")
-
-      assert_equal "Name en",  u.name
-      assert_equal "Name pl",  u.name_pl
-      assert_nil  u.title
-      assert_nil  u.title_pl
-    end
   end
 
   test "globalize locales on class without locales specified in options" do

--- a/test/globalize_accessors_test.rb
+++ b/test/globalize_accessors_test.rb
@@ -22,12 +22,6 @@ class GlobalizeAccessorsTest < ActiveSupport::TestCase
     globalize_accessors :locales => [:de], :attributes => [:color]
   end
 
-  class UnitWithAttrAccessible < ActiveRecord::Base
-    self.table_name = :units
-    translates :name, :title
-    globalize_accessors
-  end
-
   class UnitWithDashedLocales < ActiveRecord::Base
     self.table_name = :units
     translates :name

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ plugin_test_dir = File.dirname(__FILE__)
 
 ActiveRecord::Base.logger = Logger.new(File.join(plugin_test_dir, "debug.log"))
 ActiveRecord::Base.configurations = YAML::load(  IO.read( File.join(plugin_test_dir, 'db', 'database.yml')  ) )
-ActiveRecord::Base.establish_connection("sqlite3mem")
+ActiveRecord::Base.establish_connection(:sqlite3mem)
 ActiveRecord::Migration.verbose = false
+ActiveSupport::TestCase.test_order = :sorted
 load(File.join(plugin_test_dir, "db", "schema.rb"))


### PR DESCRIPTION
Can we bump version to 0.2.0 for new release and drop older rails versions support?