### PR TITLE
Update globalize-accessors.gemspec

### DIFF
--- a/globalize-accessors.gemspec
+++ b/globalize-accessors.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3"
   s.rubyforge_project         = "globalize-accessors"
 
-  s.add_dependency "globalize", "~> 5.0.0"
+  s.add_dependency "globalize", "~> 5.1.0"
   s.add_development_dependency "bundler", "~> 1.7.2"
   s.add_development_dependency "rake", "~> 0.9.2"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Depend on `globalize` `5.1.0` to avoid

```
Bundler could not find compatible versions for gem "globalize":
  In Gemfile:
    globalize-accessors (>= 0) ruby depends on
      globalize (~> 5.0.0) ruby

    globalize (5.1.0)
```