### PR TITLE
Update code example in readme to preserve any existing options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ If you wish to always define accessors and don't want to call the `globalize_acc
 module TranslatesWithAccessors
 
   def translates(*params)
-    options = params.extract_options!
+    options = params.dup.extract_options!
     options.reverse_merge!(:globalize_accessors => true)
     accessors = options.delete(:globalize_accessors)
     super


### PR DESCRIPTION
Before this commit, if we specify options for `translates` on a model, those options will be silently dropped if we integrate this example code.

To illustrate, if we have a model with a translated field, e.g.

```
class MyModel < ActiveRecord::Base
  translates :label, fallbacks_for_empty_translations: true
end
```

Then with the original example code, the call to `params.extract_options!` will cause our added option (`fallbacks_for_empty_translations`) to be removed from `params`. When `super` is called, `params` will be passed automatically, but it will now be missing any options we have specified at the model level. The net effect is that fallbacks for empty translations will not be enabled as expected.

Working with a copy of the passed `params` works around this issue.