### PR TITLE
Fix DEPRECATION WARNING: `#{field}_#{locale}` is not an attribute

### DIFF
--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -22,6 +22,7 @@ module Globalize::Accessors
   private
 
   def define_accessors(attr_name, locale)
+    attribute("#{attr_name}_#{locale}", ::ActiveRecord::Type::Value.new)
     define_getter(attr_name, locale)
     define_setter(attr_name, locale)
   end

--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -22,7 +22,7 @@ module Globalize::Accessors
   private
 
   def define_accessors(attr_name, locale)
-    attribute("#{attr_name}_#{locale}", ::ActiveRecord::Type::Value.new)
+    attribute("#{attr_name}_#{locale}", ::ActiveRecord::Type::Value.new) if ::ActiveRecord::VERSION::STRING >= "5.0"
     define_getter(attr_name, locale)
     define_setter(attr_name, locale)
   end


### PR DESCRIPTION
known to Active Record. This behavior is deprecated and will be
removed in the next version of Rails.