### PR TITLE
Loosen Globalize version

### DIFF
--- a/globalize-accessors.gemspec
+++ b/globalize-accessors.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3"
   s.rubyforge_project         = "globalize-accessors"
 
-  s.add_dependency "globalize", [">= 5.0.0", "~> 5.0"]
+  s.add_dependency "globalize", ">= 5.0.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rake"

--- a/lib/globalize-accessors/version.rb
+++ b/lib/globalize-accessors/version.rb
@@ -1,5 +1,5 @@
 module Globalize
   module Accessors
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
   end
 end

--- a/lib/globalize-accessors/version.rb
+++ b/lib/globalize-accessors/version.rb
@@ -1,5 +1,5 @@
 module Globalize
   module Accessors
-    VERSION = '0.2.2'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
I need this in order to continue using the gem with Rails 6.1 (Globalize 6.0)

Can someone release it please? 🙏 cc @parndt 