### PR TITLE
Fix ActiveRecord load order

### DIFF
--- a/globalize-accessors.gemspec
+++ b/globalize-accessors.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3"
   s.rubyforge_project         = "globalize-accessors"
 
+  s.add_dependency 'activesupport', '>= 4.2', '< 7.2'
   s.add_dependency "globalize", ">= 5.0.0"
 
   s.add_development_dependency "sqlite3"

--- a/globalize-accessors.gemspec
+++ b/globalize-accessors.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3"
   s.rubyforge_project         = "globalize-accessors"
 
-  s.add_dependency 'activesupport', '>= 4.2', '< 7.2'
+  s.add_dependency 'activesupport', '>= 4.2'
   s.add_dependency "globalize", ">= 5.0.0"
 
   s.add_development_dependency "sqlite3"

--- a/lib/globalize-accessors.rb
+++ b/lib/globalize-accessors.rb
@@ -61,4 +61,6 @@ module Globalize::Accessors
   end
 end
 
-ActiveRecord::Base.extend Globalize::Accessors
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.extend Globalize::Accessors
+end


### PR DESCRIPTION
Fixes #45
> Globalize load ActiveRecord too early (before initializers)

Which meant that setting active_record configuration in initializers did not work.